### PR TITLE
add option for `azure_ad_token_provider` to `OpenAiAzureChat`

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,7 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        # only test high and low version numbers
+        python-version: ["3.9", "3.12"]
+        # python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     # https://github.com/actions/checkout

--- a/LICENSE
+++ b/LICENSE
@@ -3,7 +3,7 @@ MIT License
 Copyright (c) 2023-2024 Philip May
 Copyright (c) 2023-2024 Philip May, Deutsche Telekom AG
 Copyright (c) 2023-2024 Alaeddine Abdessalem, Deutsche Telekom AG
-Copyright (c) 2024-2025 Sijun John Tu, Deutsche Telekom AG
+Copyright (c) 2025 Sijun John Tu, Deutsche Telekom AG
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -3,6 +3,7 @@ MIT License
 Copyright (c) 2023-2024 Philip May
 Copyright (c) 2023-2024 Philip May, Deutsche Telekom AG
 Copyright (c) 2023-2024 Alaeddine Abdessalem, Deutsche Telekom AG
+Copyright (c) 2024-2025 Sijun John Tu, Deutsche Telekom AG
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To install those module specific dependencies see
 Copyright (c) 2023-2024 [Philip May](https://philipmay.org)\
 Copyright (c) 2023-2024 [Philip May](https://philipmay.org), [Deutsche Telekom AG](https://www.telekom.de/)\
 Copyright (c) 2023-2024 Alaeddine Abdessalem, [Deutsche Telekom AG](https://www.telekom.de/)\
-Copyright (c) 2024-2025 Sijun John Tu, [Deutsche Telekom AG](https://www.telekom.de/)
+Copyright (c) 2025 Sijun John Tu, [Deutsche Telekom AG](https://www.telekom.de/)
 
 Licensed under the **MIT License** (the "License"); you may not use this file except in compliance with the License.
 You may obtain a copy of the License by reviewing the file

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ To install those module specific dependencies see
 Copyright (c) 2023-2024 [Philip May](https://philipmay.org)\
 Copyright (c) 2023-2024 [Philip May](https://philipmay.org), [Deutsche Telekom AG](https://www.telekom.de/)\
 Copyright (c) 2023-2024 Alaeddine Abdessalem, [Deutsche Telekom AG](https://www.telekom.de/)
+\
+Copyright (c) 2024-2025 Sijun John Tu, [Deutsche Telekom AG](https://www.telekom.de/)
 
 Licensed under the **MIT License** (the "License"); you may not use this file except in compliance with the License.
 You may obtain a copy of the License by reviewing the file

--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ To install those module specific dependencies see
 
 Copyright (c) 2023-2024 [Philip May](https://philipmay.org)\
 Copyright (c) 2023-2024 [Philip May](https://philipmay.org), [Deutsche Telekom AG](https://www.telekom.de/)\
-Copyright (c) 2023-2024 Alaeddine Abdessalem, [Deutsche Telekom AG](https://www.telekom.de/)
-\
+Copyright (c) 2023-2024 Alaeddine Abdessalem, [Deutsche Telekom AG](https://www.telekom.de/)\
 Copyright (c) 2024-2025 Sijun John Tu, [Deutsche Telekom AG](https://www.telekom.de/)
 
 Licensed under the **MIT License** (the "License"); you may not use this file except in compliance with the License.

--- a/mltb2/openai.py
+++ b/mltb2/openai.py
@@ -364,7 +364,7 @@ class OpenAiAzureChat(OpenAiChat, _OpenAiAzureChatBase):
     api_version: Optional[str] = None
     api_key: Optional[str] = None
     azure_ad_token: Optional[str] = None
-    azure_ad_token_provider: Optional[Union[AzureADTokenProvider, str]] = None
+    azure_ad_token_provider: Union[AzureADTokenProvider, str, None] = None
 
     def __post_init__(self) -> None:
         """Do post init."""
@@ -397,7 +397,7 @@ class OpenAiAzureChat(OpenAiChat, _OpenAiAzureChatBase):
         yaml_file,
         api_key: Optional[str] = None,
         azure_ad_token: Optional[str] = None,
-        azure_ad_token_provider: Optional[Union[AzureADTokenProvider, str]] = None,
+        azure_ad_token_provider: Union[AzureADTokenProvider, str, None] = None,
         **kwargs,
     ):
         """Construct this class from a yaml file.

--- a/mltb2/openai.py
+++ b/mltb2/openai.py
@@ -364,7 +364,7 @@ class OpenAiAzureChat(OpenAiChat, _OpenAiAzureChatBase):
     api_version: Optional[str] = None
     api_key: Optional[str] = None
     azure_ad_token: Optional[str] = None
-    azure_ad_token_provider: Optional[Union[AzureADTokenProvider, str]] = "auto" # default value
+    azure_ad_token_provider: Optional[Union[AzureADTokenProvider, str]] = "auto"  # noqa: S105
 
     def __post_init__(self) -> None:
         """Do post init."""
@@ -397,7 +397,7 @@ class OpenAiAzureChat(OpenAiChat, _OpenAiAzureChatBase):
         yaml_file,
         api_key: Optional[str] = None,
         azure_ad_token: Optional[str] = None,
-        azure_ad_token_provider: Optional[Union[AzureADTokenProvider, str]] = "auto",
+        azure_ad_token_provider: Optional[Union[AzureADTokenProvider, str]] = "auto",  # NOQA: S107
         **kwargs,
     ):
         """Construct this class from a yaml file.

--- a/mltb2/openai.py
+++ b/mltb2/openai.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2023-2025 Philip May
 # Copyright (c) 2024-2025 Philip May, Deutsche Telekom AG
 # Copyright (c) 2024 Alaeddine Abdessalem, Deutsche Telekom AG
-# Copyright (c) 2024 Sijun John Tu, Deutsche Telekom AG
+# Copyright (c) 2025 Sijun John Tu, Deutsche Telekom AG
 # This software is distributed under the terms of the MIT license
 # which is available at https://opensource.org/licenses/MIT
 

--- a/mltb2/openai.py
+++ b/mltb2/openai.py
@@ -350,6 +350,7 @@ class OpenAiAzureChat(OpenAiChat, _OpenAiAzureChatBase):
     See Also:
         * OpenAI API reference: `Create chat completion <https://platform.openai.com/docs/api-reference/chat/create>`_
         * `Quickstart: Get started generating text using Azure OpenAI Service <https://learn.microsoft.com/en-us/azure/ai-services/openai/quickstart?tabs=command-line&pivots=programming-language-python>`_
+        * ```AzureADTokenProvider`` example <https://github.com/openai/openai-python/blob/main/examples/azure_ad.py>`_
 
     Args:
         api_key: The OpenAI API key.

--- a/mltb2/openai.py
+++ b/mltb2/openai.py
@@ -22,7 +22,7 @@ import tiktoken
 import yaml
 from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 from openai import AsyncAzureOpenAI, AsyncOpenAI, AzureOpenAI, OpenAI
-from openai.lib.azure import AzureADTokenProvider  # TODO: what about AsyncAzureADTokenProvider ?
+from openai.lib.azure import AzureADTokenProvider
 from openai.types.chat import ChatCompletion
 from tiktoken.core import Encoding
 from tqdm import tqdm

--- a/mltb2/openai.py
+++ b/mltb2/openai.py
@@ -364,7 +364,7 @@ class OpenAiAzureChat(OpenAiChat, _OpenAiAzureChatBase):
     api_version: Optional[str] = None
     api_key: Optional[str] = None
     azure_ad_token: Optional[str] = None
-    azure_ad_token_provider: Optional[Union[AzureADTokenProvider, str]] = "auto"  # noqa: S105
+    azure_ad_token_provider: Optional[Union[AzureADTokenProvider, str]] = None
 
     def __post_init__(self) -> None:
         """Do post init."""
@@ -397,7 +397,7 @@ class OpenAiAzureChat(OpenAiChat, _OpenAiAzureChatBase):
         yaml_file,
         api_key: Optional[str] = None,
         azure_ad_token: Optional[str] = None,
-        azure_ad_token_provider: Optional[Union[AzureADTokenProvider, str]] = "auto",  # NOQA: S107
+        azure_ad_token_provider: Optional[Union[AzureADTokenProvider, str]] = None,
         **kwargs,
     ):
         """Construct this class from a yaml file.

--- a/mltb2/openai.py
+++ b/mltb2/openai.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2023-2024 Philip May
-# Copyright (c) 2024 Philip May, Deutsche Telekom AG
+# Copyright (c) 2023-2025 Philip May
+# Copyright (c) 2024-2025 Philip May, Deutsche Telekom AG
 # Copyright (c) 2024 Alaeddine Abdessalem, Deutsche Telekom AG
 # Copyright (c) 2024 Sijun John Tu, Deutsche Telekom AG
 # This software is distributed under the terms of the MIT license

--- a/mltb2/openai.py
+++ b/mltb2/openai.py
@@ -16,14 +16,14 @@ Hint:
 import os
 from collections.abc import Iterable
 from dataclasses import dataclass, field
-from typing import Any, Optional, Union
+from typing import Any, Optional, Union, cast
 
 import tiktoken
 import yaml
-from openai import AsyncAzureOpenAI, AsyncOpenAI, AzureOpenAI, OpenAI
-from openai.types.chat import ChatCompletion
-from openai.lib.azure import AzureADTokenProvider, AsyncAzureADTokenProvider
 from azure.identity import DefaultAzureCredential, get_bearer_token_provider
+from openai import AsyncAzureOpenAI, AsyncOpenAI, AzureOpenAI, OpenAI
+from openai.lib.azure import AzureADTokenProvider  # TODO: what about AsyncAzureADTokenProvider ?
+from openai.types.chat import ChatCompletion
 from tiktoken.core import Encoding
 from tqdm import tqdm
 
@@ -356,7 +356,8 @@ class OpenAiAzureChat(OpenAiChat, _OpenAiAzureChatBase):
         model: The OpenAI model name.
         api_version: The OpenAI API version.
             A common value for this is ``2023-05-15``.
-        azure_ad_token_provider: either a token provider or set to "auto" to use default credentials taken from azure CLI
+        azure_ad_token_provider: either a token provider or
+            set to "auto" to use default credentials taken from azure CLI
         azure_endpoint: The Azure endpoint.
     """
 
@@ -367,12 +368,13 @@ class OpenAiAzureChat(OpenAiChat, _OpenAiAzureChatBase):
 
     def __post_init__(self) -> None:
         """Do post init."""
-
         # init default token provider if azure_ad_token_provider=="auto"
-        if self.azure_ad_token_provider == "auto":
+        if self.azure_ad_token_provider == "auto":  # NOQA: S105
             self.azure_ad_token_provider = get_bearer_token_provider(
                 DefaultAzureCredential(), "https://cognitiveservices.azure.com/.default"
             )
+
+        self.azure_ad_token_provider = cast("Optional[AzureADTokenProvider]", self.azure_ad_token_provider)
 
         self.client = AzureOpenAI(
             api_key=self.api_key,
@@ -423,7 +425,7 @@ class OpenAiAzureChat(OpenAiChat, _OpenAiAzureChatBase):
         ## method parameter > yaml
         azure_ad_token_provider = azure_ad_token_provider or completion_kwargs.get("azure_ad_token_provider")
         ## if token_provider==auto use default settings
-        if azure_ad_token_provider == "auto":
+        if azure_ad_token_provider == "auto":  # NOQA: S105
             azure_ad_token_provider = get_bearer_token_provider(
                 DefaultAzureCredential(), "https://cognitiveservices.azure.com/.default"
             )

--- a/mltb2/openai.py
+++ b/mltb2/openai.py
@@ -363,7 +363,7 @@ class OpenAiAzureChat(OpenAiChat, _OpenAiAzureChatBase):
     api_version: Optional[str] = None
     api_key: Optional[str] = None
     azure_ad_token: Optional[str] = None
-    azure_ad_token_provider: Optional[Union[AzureADTokenProvider, str]] = None
+    azure_ad_token_provider: Optional[Union[AzureADTokenProvider, str]] = "auto" # default value
 
     def __post_init__(self) -> None:
         """Do post init."""
@@ -395,7 +395,7 @@ class OpenAiAzureChat(OpenAiChat, _OpenAiAzureChatBase):
         yaml_file,
         api_key: Optional[str] = None,
         azure_ad_token: Optional[str] = None,
-        azure_ad_token_provider: Optional[Union[AzureADTokenProvider, str]] = None,
+        azure_ad_token_provider: Optional[Union[AzureADTokenProvider, str]] = "auto",
         **kwargs,
     ):
         """Construct this class from a yaml file.

--- a/mltb2/openai.py
+++ b/mltb2/openai.py
@@ -19,8 +19,9 @@ from typing import Any, Optional, Union
 
 import tiktoken
 import yaml
-from openai import AsyncAzureOpenAI, AsyncOpenAI, AzureOpenAI, OpenAI
+from openai import AsyncAzureOpenAI, AsyncOpenAI, AzureOpenAI, OpenAI 
 from openai.types.chat import ChatCompletion
+from openai.lib.azure import AzureADTokenProvider, AsyncAzureADTokenProvider
 from tiktoken.core import Encoding
 from tqdm import tqdm
 
@@ -359,6 +360,7 @@ class OpenAiAzureChat(OpenAiChat, _OpenAiAzureChatBase):
     api_version: Optional[str] = None
     api_key: Optional[str] = None
     azure_ad_token: Optional[str] = None
+    azure_ad_token_provider: Optional[AzureADTokenProvider] = None
 
     def __post_init__(self) -> None:
         """Do post init."""
@@ -367,12 +369,14 @@ class OpenAiAzureChat(OpenAiChat, _OpenAiAzureChatBase):
             api_version=self.api_version,
             azure_endpoint=self.azure_endpoint,
             azure_ad_token=self.azure_ad_token,
+            azure_ad_token_provider = self.azure_ad_token_provider
         )
         self.async_client = AsyncAzureOpenAI(
             api_key=self.api_key,
             api_version=self.api_version,
             azure_endpoint=self.azure_endpoint,
             azure_ad_token=self.azure_ad_token,
+            azure_ad_token_provider = self.azure_ad_token_provider
         )
 
     @classmethod

--- a/mltb2/openai.py
+++ b/mltb2/openai.py
@@ -23,6 +23,7 @@ import yaml
 from openai import AsyncAzureOpenAI, AsyncOpenAI, AzureOpenAI, OpenAI
 from openai.types.chat import ChatCompletion
 from openai.lib.azure import AzureADTokenProvider, AsyncAzureADTokenProvider
+from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 from tiktoken.core import Encoding
 from tqdm import tqdm
 
@@ -355,33 +356,48 @@ class OpenAiAzureChat(OpenAiChat, _OpenAiAzureChatBase):
         model: The OpenAI model name.
         api_version: The OpenAI API version.
             A common value for this is ``2023-05-15``.
+        azure_ad_token_provider: either a token provider or set to "auto" to use default credentials taken from azure CLI
         azure_endpoint: The Azure endpoint.
     """
 
     api_version: Optional[str] = None
     api_key: Optional[str] = None
     azure_ad_token: Optional[str] = None
-    azure_ad_token_provider: Optional[AzureADTokenProvider] = None
+    azure_ad_token_provider: Optional[Union[AzureADTokenProvider, str]] = None
 
     def __post_init__(self) -> None:
         """Do post init."""
+
+        # init default token provider if azure_ad_token_provider=="auto"
+        if self.azure_ad_token_provider == "auto":
+            self.azure_ad_token_provider = get_bearer_token_provider(
+                DefaultAzureCredential(), "https://cognitiveservices.azure.com/.default"
+            )
+
         self.client = AzureOpenAI(
             api_key=self.api_key,
             api_version=self.api_version,
             azure_endpoint=self.azure_endpoint,
             azure_ad_token=self.azure_ad_token,
-            azure_ad_token_provider = self.azure_ad_token_provider
+            azure_ad_token_provider=self.azure_ad_token_provider,
         )
         self.async_client = AsyncAzureOpenAI(
             api_key=self.api_key,
             api_version=self.api_version,
             azure_endpoint=self.azure_endpoint,
             azure_ad_token=self.azure_ad_token,
-            azure_ad_token_provider = self.azure_ad_token_provider
+            azure_ad_token_provider=self.azure_ad_token_provider,
         )
 
     @classmethod
-    def from_yaml(cls, yaml_file, api_key: Optional[str] = None, azure_ad_token: Optional[str] = None, **kwargs):
+    def from_yaml(
+        cls,
+        yaml_file,
+        api_key: Optional[str] = None,
+        azure_ad_token: Optional[str] = None,
+        azure_ad_token_provider: Optional[Union[AzureADTokenProvider, str]] = None,
+        **kwargs,
+    ):
         """Construct this class from a yaml file.
 
         If the ``api_key`` is not set in the yaml file,
@@ -391,6 +407,7 @@ class OpenAiAzureChat(OpenAiChat, _OpenAiAzureChatBase):
             yaml_file: The yaml file.
             api_key: The OpenAI API key.
             azure_ad_token: Azure AD token
+            azure_ad_token_provider: token provider
             kwargs: extra kwargs to override parameters
         Returns:
             The constructed class.
@@ -401,4 +418,20 @@ class OpenAiAzureChat(OpenAiChat, _OpenAiAzureChatBase):
         # set azure_ad_token according to this priority:
         # method parameter > yaml > environment variable
         azure_ad_token = azure_ad_token or completion_kwargs.get("AZURE_AD_TOKEN") or os.getenv("AZURE_AD_TOKEN")
-        return super().from_yaml(yaml_file, api_key=api_key, azure_ad_token=azure_ad_token, **kwargs)
+
+        # init the token provider
+        ## method parameter > yaml
+        azure_ad_token_provider = azure_ad_token_provider or completion_kwargs.get("azure_ad_token_provider")
+        ## if token_provider==auto use default settings
+        if azure_ad_token_provider == "auto":
+            azure_ad_token_provider = get_bearer_token_provider(
+                DefaultAzureCredential(), "https://cognitiveservices.azure.com/.default"
+            )
+
+        return super().from_yaml(
+            yaml_file,
+            api_key=api_key,
+            azure_ad_token=azure_ad_token,
+            azure_ad_token_provider=azure_ad_token_provider,
+            **kwargs,
+        )

--- a/mltb2/openai.py
+++ b/mltb2/openai.py
@@ -357,8 +357,10 @@ class OpenAiAzureChat(OpenAiChat, _OpenAiAzureChatBase):
         model: The OpenAI model name.
         api_version: The OpenAI API version.
             A common value for this is ``2023-05-15``.
-        azure_ad_token_provider: either a token provider or
-            set to "auto" to use default credentials taken from azure CLI
+        azure_ad_token: The Azure Active Directory token.
+        azure_ad_token_provider: A function that returns an Azure Active Directory token,
+            which will be invoked on every request.
+            Or set to "auto" to use default credentials.
         azure_endpoint: The Azure endpoint.
     """
 
@@ -409,8 +411,10 @@ class OpenAiAzureChat(OpenAiChat, _OpenAiAzureChatBase):
         Args:
             yaml_file: The yaml file.
             api_key: The OpenAI API key.
-            azure_ad_token: Azure AD token
-            azure_ad_token_provider: token provider
+            azure_ad_token: The Azure Active Directory token.
+            azure_ad_token_provider: A function that returns an Azure Active Directory token,
+                which will be invoked on every request.
+                Or set to "auto" to use default credentials.
             kwargs: extra kwargs to override parameters
         Returns:
             The constructed class.

--- a/mltb2/openai.py
+++ b/mltb2/openai.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2023-2024 Philip May
 # Copyright (c) 2024 Philip May, Deutsche Telekom AG
 # Copyright (c) 2024 Alaeddine Abdessalem, Deutsche Telekom AG
+# Copyright (c) 2024 Sijun John Tu, Deutsche Telekom AG
 # This software is distributed under the terms of the MIT license
 # which is available at https://opensource.org/licenses/MIT
 
@@ -19,7 +20,7 @@ from typing import Any, Optional, Union
 
 import tiktoken
 import yaml
-from openai import AsyncAzureOpenAI, AsyncOpenAI, AzureOpenAI, OpenAI 
+from openai import AsyncAzureOpenAI, AsyncOpenAI, AzureOpenAI, OpenAI
 from openai.types.chat import ChatCompletion
 from openai.lib.azure import AzureADTokenProvider, AsyncAzureADTokenProvider
 from tiktoken.core import Encoding

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ python-arango = {version = "*", optional = true}
 jsonlines = {version = "*", optional = true}
 markdownify = {version = "*", optional = true}
 mdformat = {version = "*", optional = true}
+azure-identity = {version = "*", optional = true}
 
 [tool.poetry.extras]
 files = ["platformdirs", "scikit-learn", "joblib"]
@@ -95,7 +96,7 @@ somajo = ["SoMaJo"]
 transformers = ["scikit-learn", "torch", "transformers", "safetensors"]
 md = ["scikit-learn", "torch", "transformers", "safetensors"]
 somajo_transformers = ["SoMaJo", "scikit-learn", "torch", "transformers", "safetensors"]
-openai = ["tiktoken", "openai", "pyyaml"]
+openai = ["tiktoken", "openai", "pyyaml", "azure-identity"]
 arangodb = ["python-dotenv", "python-arango", "jsonlines"]
 bs = ["beautifulsoup4", "markdownify", "mdformat"]
 


### PR DESCRIPTION
## Description

we can now initialise the OpenAiAzureChat using an `azure_ad_token_provider`. Using the token provider we do not need to pass an AD token manually. This is especially useful when an azure ML job is queuing for a long time and the provided AD token has expired.

Here is an Example:
```
from mltb2.openai import OpenAiAzureChat
from azure.identity import DefaultAzureCredential, get_bearer_token_provider

# define resource
scopes = "https://cognitiveservices.azure.com/.default"
api_version = "2023-07-01-preview"
endpoint = "https://my-resource.openai.azure.com/"

# init token provider
token_provider = get_bearer_token_provider(DefaultAzureCredential(), scopes)

# init OpenAiAzureChat class
chat = OpenAiAzureChat(azure_ad_token_provider=token_provider, 
                azure_endpoint=endpoint, 
                model="GPT-4o",
                api_version=api_version)

# run a completion
chat.create_completions(prompt="hello")
```

## Pull request checklist

- tests
  - [x] Do we have tests? Should we add more?
  - [x] Should we parametrize tests?
  - [x] Should we add hypothesis tests?
- documentation
  - [x] add docstrings
  - [x] if a module is new: add API reference file for Sphinx in `docs/source/api-reference`
  - [x] check API doc of Sphinx - build and show with `make sphinx && make open-sphinx`
- [x] fix checks
  - start locale checks with `make check`
  - fix formatting with `make format`
- Python type info
  - [x] check and improve Python type info
  - [x] double check if return types are specified - including `-> None`
- [x] check TODO comments in code
- [x] check FIXME comments in code
- [x] check if we want to increase the version or rc number
- [x] check if the copyright needs an update
  - file header
  - README.md
  - LICENSE file
